### PR TITLE
Correct README sub-heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Commands for handling a zettelkasten with Luhmann-style IDs (e.g: 12a56g) as fil
 
 ## Commands
 
-### Create sibling note
+### Create child notes
 
 Creates a note **under** the current note, e.g: If run from "23f3.md", "12f3a.md" (or the next available sibling) will be created. 
 


### PR DESCRIPTION
The text of the first sub-heading was "Create sibling note", but the content below it was about creating child notes.  Corrected sub-heading to "Create child note".

Fixes Dyldog/luhman-obsidian-plugin#4