### PR TITLE
Don't insert empty title in new notes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -230,7 +230,12 @@ export default class NewZettel extends Plugin {
     placeCursorAtStartOfContent: boolean
   ) {
     let app = this.app;
-    let titleContent = "# " + title + "\n\n";
+    let titleContent = null;
+    if (title && title.length > 0) {
+      titleContent = "# " + title + "\n\n";
+    } else {
+      titleContent = ""; 
+    }
     let fullContent = titleContent + content;
     let file = await this.app.vault.create(path, fullContent);
     let active = app.workspace.getLeaf();


### PR DESCRIPTION
Not setting a title when creating a new note results in the new note getting a title "# \n\n" by default. This change drops that default title if the user hasn't set one.