### PR TITLE
Fix ignore filter in getZettels

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -482,10 +482,10 @@ export default class NewZettel extends Plugin {
 
   getZettels(): TFile[] {
     return this.app.vault.getMarkdownFiles().filter(file => {
-      const ignore = /^[_layouts|templates|scripts]/;
+      const ignore = /^(_layouts|templates|scripts)/;
       return
         this.fileToId(file.basename) !== '' &&
-        file.path.match(ignore) == null;
+        file.path?.match(ignore) === null;
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -485,7 +485,7 @@ export default class NewZettel extends Plugin {
       const ignore = /^(_layouts|templates|scripts)/;
       return
         this.fileToId(file.basename) !== '' &&
-        file.path?.match(ignore) === null;
+        file.path?.match(ignore) == null;
     });
   }
 


### PR DESCRIPTION
Possibly a fix for the issues in #11 (after additionally switching to fuzzy matcher). The ignore pattern was using single-character matches instead of whole-word matches. 

To be safe I also made the filter conditional on the `.path` property being present — I’m not sure whether this is needed, but since it’s not part of the TFile API spec I’m guessing it might not exist on some harder-to-debug platforms.