### PR TITLE
Add 2 new commands that address feature #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Sections are used under each version as follows:
 - Added beta versions (via [BRAT]).
 - Added notifications for some failures.
 - Added CHANGELOG.
+- Added `Open New Zettel on Creation` checkbox on Model screen
+- Added new command `New Child Zettel Note (Don't Open)` same as `New Child Zettel Note` but defaults `Open New Zettel on Creation` to false
+- Added new command `New Sibling Zettel Note (Don't Open)` same as `New Sibling Zettel Note` but defaults `Open New Zettel on Creation` to false
 
 ### Fixed
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -6,3 +6,26 @@
   flex-grow: 100;
   margin-right: 10px;
 }
+
+.zettel-modal-container.zettel-options-container {
+  margin-top: 0.5em;
+  display: flex;
+  flex-direction: column;
+}
+
+.zettel-modal-container.zettel-options-container .zettel-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zettel-modal-container.zettel-options-container .labelText {
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+}
+  
+.zettel-modal-container.zettel-options-container input[type=checkbox] {
+  width: 2em;
+  height: 2em;
+}


### PR DESCRIPTION
# PR Details
This PR does some refactoring and supports 2 new commands 
* New Sibling Zettel Note (Don't Open)
* New Child Zettel Note (Don't Open)

## Refactoring
The refactoring makes the model support an options object that is passed in with defaults and then passed back allowing the user to preform a per model action override of behavior.

## Screenshots
![image](https://user-images.githubusercontent.com/725683/189601857-d0644a31-95e7-4e55-beca-15f0d76557be.png)
![image](https://user-images.githubusercontent.com/725683/189601880-390bb4d0-38ab-4a88-9a2b-0205de399d92.png)
![image](https://user-images.githubusercontent.com/725683/189601964-0b467c03-2610-4947-b89e-861c4519ad8f.png)

