### PR TITLE
feat: add setting to set title as alias in children/siblings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import {
   Setting,
   TFile,
   Notice,
-  parseFrontMatterStringArray,
 } from "obsidian";
 import "./styles/styles.css";
 


### PR DESCRIPTION
## Context
- ZK prefixes can be noisy, and adding alias makes linking easier and notes cleaner

## Solution
- add setting to enable aliases created
- add title as alias in child/sibling frontmatter
- add setting to enable title alias in parent file link