### PR TITLE
fix: add mobile toolbar icons

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -483,6 +483,7 @@ export default class NewZettel extends Plugin {
     this.addCommand({
       id: "new-sibling-note",
       name: "New Sibling Zettel Note",
+      icon: 'file-symlink',
       callback: () => {
         this.makeNoteFunction(this.makeNoteForNextSiblingOf);
       },
@@ -491,6 +492,7 @@ export default class NewZettel extends Plugin {
     this.addCommand({
       id: "new-child-note",
       name: "New Child Zettel Note",
+      icon: 'file-down',
       callback: () => {
         this.makeNoteFunction(this.makeNoteForNextChildOf);
       },
@@ -499,6 +501,7 @@ export default class NewZettel extends Plugin {
     this.addCommand({
       id: "new-sibling-note-dont-open",
       name: "New Sibling Zettel Note (Don't Open)",
+      icon: 'file-symlink',
       callback: () => {
         this.makeNoteFunction(this.makeNoteForNextSiblingOf, false);
       },
@@ -507,6 +510,7 @@ export default class NewZettel extends Plugin {
     this.addCommand({
       id: "new-child-note-dont-open",
       name: "New Child Zettel Note (Don't Open)",
+      icon: 'file-down',
       callback: () => {
         this.makeNoteFunction(this.makeNoteForNextChildOf, false);
       },


### PR DESCRIPTION
## Context

create child and create sibling commands don't have icons associated, in mobile toolbar it shows as "?"


## Solution

- sibling uses https://lucide.dev/icon/file-symlink icon
- child uses https://lucide.dev/icon/file-down